### PR TITLE
もくもく会一覧変更, 詳細ページのロジック変更

### DIFF
--- a/backend/laravel/app/Services/Master/PartyService.php
+++ b/backend/laravel/app/Services/Master/PartyService.php
@@ -17,8 +17,9 @@ class PartyService
     public function fetchPickUpParties(int $auth_id): array
     {
         $sevendays=Carbon::today()->subDay(7);
-        //todo:取得ロジックの変更をユニットテストに繁栄
+        //todo:取得ロジックの変更をユニットテストに反映
         $parties = Party::with(['tags', 'users'])->whereDate('created_at', '>=', $sevendays)
+        ->where('leader_id', '!=', $auth_id)
         ->where(function ($query) use ($auth_id) {
             $query->whereHas('users', function ($q) use ($auth_id) {
                 $q->whereNotIn('id', [$auth_id]);

--- a/backend/laravel/app/Services/PartyService.php
+++ b/backend/laravel/app/Services/PartyService.php
@@ -13,7 +13,7 @@ class PartyService
     /**
      * @param array $data
      * @param integer $user_id
-     * 
+     *
      * @return void
      */
     public function register(array $data, int $user_id): void
@@ -74,8 +74,12 @@ class PartyService
     public function checkIfJoined(int $party_id): bool
     {
         $user = Auth::User();
-        $query = $user->whereHas('parties', function($query) use ($party_id){
-            $query->where('id', $party_id);
+        //todo:ロジックの変更をユニットテストに反映
+        $query = Party::where('id', $party_id)->where(function ($query) use ($user) {
+            $query->whereHas('users', function($q) use ($user){
+                $q->where('id', $user->id);
+            });
+            $query->orWhere('leader_id', $user->id);
         });
         return $query->exists();
     }

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -26,7 +26,7 @@
       <v-btn color="red" style="color:white" @click="searchParty">検索する</v-btn>
     </div>
 
-    <div v-for="(party, index) in parties" :key="index" class="party_box">
+    <div v-for="(party, index) in parties" :key="index" class="party_box" v-show="party.due_max > 0">
       <div class="picture_box">写真</div>
       <div class="content_box">
         <h1 class="theme"><router-link :to="`party/${party.id}`" style="text-decoration: none;">{{party.theme}}</router-link></h1>


### PR DESCRIPTION
(一覧)
・現在参加可能人数が0人のもくもく会は表示しない
・ログインユーザーが作成したもくもく会は表示しない
(詳細)
・参加済み, もしくはログインユーザーが作成したもくもく会は参加ボタンを押せないようにする