### PR TITLE
メッセージデータ取得方法変更

### DIFF
--- a/backend/laravel/app/Http/Controllers/MessageController.php
+++ b/backend/laravel/app/Http/Controllers/MessageController.php
@@ -48,6 +48,7 @@ class MessageController extends Controller
         return $message_lists;
     }
 
+    //todo:テスト修正
     /**
      * @param int $message_group_id
      * @return array
@@ -59,7 +60,7 @@ class MessageController extends Controller
         return $messages;
     }
 
-    //todo: テスト作成
+    //todo: 削除
     /**
      * @param int $message_group_id
      * @return string

--- a/backend/laravel/app/Services/MessageService.php
+++ b/backend/laravel/app/Services/MessageService.php
@@ -42,6 +42,7 @@ class MessageService
         return $data;
     }
 
+    //todo:テストと一緒に削除
     /**
      * @param int $message_group_id
      *
@@ -54,6 +55,7 @@ class MessageService
         return $party_theme;
     }
 
+    //todo:テスト修正
     /**
      * @param int $message_group_id
      * @param int $user_id
@@ -64,12 +66,14 @@ class MessageService
     {
         $messages = Message::where('message_group_id', $message_group_id)->with(['user'])->get();
         $data = [];
+        $data['theme'] = MessageGroup::find($message_group_id)->party->theme;
+        $data['messages'] = [];
         foreach ($messages as $key => $message) {
-            $data[$key]['id'] = $message->id;
-            $data[$key]['content'] = $message->content;
-            $data[$key]['created_at'] = $message->created_at->format('Y-m-d H:i:s');
-            $data[$key]['is_users_message'] = ($message->user->id === $user_id);
-            $data[$key]['user_name'] = $message->user->name;
+            $data['messages'][$key]['id'] = $message->id;
+            $data['messages'][$key]['content'] = $message->content;
+            $data['messages'][$key]['created_at'] = $message->created_at->format('Y-m-d H:i:s');
+            $data['messages'][$key]['is_users_message'] = ($message->user->id === $user_id);
+            $data['messages'][$key]['user_name'] = $message->user->name;
         }
         return $data;
     }

--- a/frontend/pages/message_group/_id.vue
+++ b/frontend/pages/message_group/_id.vue
@@ -38,6 +38,7 @@ export default {
     return {
       party: '',
       id: this.$route.params.id,
+      data: [],
       messages: [],
       party_theme: '',
       content: '',
@@ -49,12 +50,12 @@ export default {
   },
   async created() {
     setTimeout(() => this.$nuxt.$loading.start(), 500);
-    this.party_theme = await this.$axios.get(`api/message/get_party_theme/${this.$route.params.id}`).then(res => {
+    this.data = await this.$axios.get(`api/message/get/${this.$route.params.id}`).then(res => {
       return res.data;
     });
-    this.messages = await this.$axios.get(`api/message/get/${this.$route.params.id}`).then(res => {
-      return res.data;
-    });
+
+    this.party_theme = this.data.theme;
+    this.messages = this.data.messages;
     setInterval(() => {
       this.getMessages();
       console.log('メッセージを更新')
@@ -64,7 +65,7 @@ export default {
   methods:{
     async getMessages(){
       this.messages = await this.$axios.get(`api/message/get/${this.$route.params.id}`).then(res => {
-        return res.data;
+        return res.data.messages;
       });
     },
     async sendMessage(){


### PR DESCRIPTION
メッセージ機能の部分で、APIを2つ(メッセージ取得APIとメッセージのもくもく会タイトル取得API)に分けていたが、レスポンス速度を上げるために統合