### PR TITLE
バグ修正(ユーザー情報更新時に画像を選択しなかった場合に元の画像が消える)

### DIFF
--- a/backend/app/Services/AuthService.php
+++ b/backend/app/Services/AuthService.php
@@ -36,16 +36,16 @@ class AuthService
     /**
      * @param array $data
      *
-     * @return void
+     * @return void|string
      */
-    public function update(User $user, array $data): void
+    public function update(User $user, array $data)
     {
         if (!is_null($data['image'])) {
             $user->update([
                 'image' => $this->createS3Image($user, $data['image'])
             ]);
-            unset($data['image']);
         }
+        unset($data['image']);
 
         $user->fill($data)->save();
     }

--- a/backend/app/Services/AuthService.php
+++ b/backend/app/Services/AuthService.php
@@ -32,13 +32,12 @@ class AuthService
         }
     }
 
-    //テスト作成
     /**
      * @param array $data
      *
-     * @return void|string
+     * @return void
      */
-    public function update(User $user, array $data)
+    public function update(User $user, array $data): void
     {
         if (!is_null($data['image'])) {
             $user->update([


### PR DESCRIPTION
ユーザー更新時にunset($data['image']);が、 $data['image']がnullでない場合にのみ発動していたので常時発動するように修正