### PR TITLE
カバレッジ出力用の環境設定

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -14,3 +14,4 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
+/coverage

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - app
     volumes:
       - ./docker/web/default.conf:/etc/nginx/conf.d/default.conf
+      - ./docker/php/php.ini:/usr/local/etc/php/php.ini
       - .:/var/www/html
   app:
     build: ./docker/php

--- a/backend/docker/php/Dockerfile
+++ b/backend/docker/php/Dockerfile
@@ -13,4 +13,8 @@ RUN apt-get update \
     && apt-get install -y libpq-dev \
     && docker-php-ext-install pdo_mysql pdo_pgsql mysqli
 RUN echo "alias ll='ls -la'" >> ~/.bashrc && . ~/.bashrc
+
+RUN pecl install xdebug-2.9.8 && \
+    docker-php-ext-enable xdebug
+
 WORKDIR /var/www/html

--- a/backend/docker/php/php.ini
+++ b/backend/docker/php/php.ini
@@ -1,0 +1,6 @@
+xdebug.client_host = host.docker.internal
+xdebug.mode = debug
+xdebug.start_with_request = yes
+xdebug.discover_client_host = 0
+xdebug.remote_handler = "dbgp"
+xdebug.client_port = 9000


### PR DESCRIPTION
dockerでXdebugをインストールできるようにし、phpunit実行時にcoverageを出力できるようにする