### PR TITLE
Dockerファイル修正(php-gd導入のため)

### DIFF
--- a/backend/docker/php/Dockerfile
+++ b/backend/docker/php/Dockerfile
@@ -7,8 +7,14 @@ RUN apt-get update \
 git \
 zip \
 unzip \
-vim
+vim \
+libpq-dev \
+libfreetype6-dev \
+libjpeg62-turbo-dev \
+libpng-dev
 
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd 
 RUN apt-get update \
     && apt-get install -y libpq-dev \
     && docker-php-ext-install pdo_mysql pdo_pgsql mysqli


### PR DESCRIPTION
phpunitでUploadfileで画像のダミーデータを作成するため、dockerでphp-gdを導入できるようにする