### PR TITLE
タイトル修正

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -7,8 +7,7 @@ export default {
 
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
-    titleTemplate: '%s - frontend',
-    title: 'frontend',
+    title: 'もくもくMAP',
     htmlAttrs: {
       lang: 'en',
     },


### PR DESCRIPTION
フロント側のタイトルが「frontend-frontend」になっていたので「もくもくMAP」に修正